### PR TITLE
Add SonarCloud scan to CI/CD pipeline

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,6 +34,7 @@ jobs:
         uses: "actions/checkout@v6"
         with:
           submodules: "recursive"
+          fetch-depth: 0
 
       - uses: "jdx/mise-action@v4.0.1"
         with:
@@ -100,6 +101,11 @@ jobs:
 
       - name: "Test"
         run: "just test"
+
+      - name: "SonarCloud scan"
+        uses: "SonarSource/sonarqube-scan-action@v7"
+        env:
+          SONAR_TOKEN: "${{ secrets.SONAR_TOKEN }}"
 
       - name: "Deploy"
         run: "just deploy ${{ env.ENVIRONMENT }}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/github/license/tom-barone/JQC?color=969696)](https://github.com/tom-barone/JQC/blob/master/LICENSE)
 
-[![CICD](https://github.com/tom-barone/JQC/actions/workflows/cicd.yml/badge.svg?branch=develop)](https://github.com/tom-barone/JQC/actions/workflows/cicd.yml) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=tom-barone_JQC&metric=alert_status)](https://sonarcloud.io/summary/overall?id=tom-barone_JQC)
+[![CICD](https://github.com/tom-barone/JQC/actions/workflows/cicd.yml/badge.svg?branch=master)](https://github.com/tom-barone/JQC/actions/workflows/cicd.yml) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=tom-barone_JQC&metric=alert_status)](https://sonarcloud.io/summary/overall?id=tom-barone_JQC)
 
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=tom-barone_JQC&metric=security_rating)](https://sonarcloud.io/summary/overall?id=tom-barone_JQC) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=tom-barone_JQC&metric=reliability_rating)](https://sonarcloud.io/summary/overall?id=tom-barone_JQC) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=tom-barone_JQC&metric=sqale_rating)](https://sonarcloud.io/summary/overall?id=tom-barone_JQC) [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=tom-barone_JQC&metric=vulnerabilities)](https://sonarcloud.io/summary/overall?id=tom-barone_JQC)
 


### PR DESCRIPTION
- Re-enable SonarCloud scan from the disabled continuous-integration workflow
- Add scan step after tests, before deploy, so quality gate failures block deployment
- Add fetch-depth: 0 to checkout for full git history (needed for blame data and PR analysis)
- Fix README CI badge to point to master instead of develop