### PR TITLE
Verify postgres restic backups weekly

### DIFF
--- a/infrastructure/ansible/deploy.yml
+++ b/infrastructure/ansible/deploy.yml
@@ -55,6 +55,12 @@
         postgres_restic_backup_restic_password: "{{ lookup('env', 'RESTIC_PASSWORD') }}"
         postgres_restic_backup_postgres_container: "{{ lookup('env', 'POSTGRES_HOST') }}"
         postgres_restic_backup_postgres_user: "{{ lookup('env', 'POSTGRES_USERNAME') }}"
+    - role: "postgres_restic_backup_verify"
+      vars:
+        postgres_restic_backup_verify_postgres_user: "{{ lookup('env', 'POSTGRES_USERNAME') }}"
+        postgres_restic_backup_verify_postgres_database: "{{ lookup('env', 'POSTGRES_DB') }}"
+        postgres_restic_backup_verify_queries:
+          - "SELECT (COUNT(*) > 10000) FROM applications"
     - role: "restic_backup"
       vars:
         restic_backup_dir: "/opt/active-storage-backup"


### PR DESCRIPTION
- Wire the `postgres_restic_backup_verify` role into `deploy.yml`
- Asserts `applications` row count > 10,000 against the latest restored snapshot
- Bumps `ansible-common` to pick up the new `postgres_restic_backup_verify_postgres_database` variable (tom-barone/ansible-common#34) so queries run against `jqc_production` rather than the default `postgres` admin db
- Cron defaults to Sunday 04:00 UTC, well after the nightly backup at 03:00