### PR TITLE
Fix flaky application types inline-add system test

### DIFF
--- a/test/system/settings/application_types_test.rb
+++ b/test/system/settings/application_types_test.rb
@@ -28,6 +28,8 @@ module Settings
       end
       click_save_settings
 
+      assert_current_path '/'
+
       click_settings_link
 
       assert_selector "input[value='DA']"


### PR DESCRIPTION
- Fix intermittent failure of `Settings::ApplicationTypesTest#test_creating_a_new_application_type_via_inline_add`
- Root cause: after `click_save_settings`, Capybara/Selenium did not reliably wait for the form's PATCH and redirect to land before the next `click_settings_link` fired, so the in-flight save could be clobbered and the new record never reached the DB
- Add a waiting `assert_current_path '/'` between save and the follow-up navigation to force Capybara to wait for the redirect
- Verified locally: targeted test 10/10 green, full test file green, full suite (227 runs / 746 assertions) green