### PR TITLE
Add system_swapfile role to ansible deploy

### DIFF
--- a/infrastructure/ansible/deploy.yml
+++ b/infrastructure/ansible/deploy.yml
@@ -24,6 +24,7 @@
       vars:
         system_hostname_short: "jqc-{{ lookup('env', 'ENVIRONMENT') }}"
         system_hostname_fqdn: "{{ lookup('env', 'JQC_HOSTNAME') }}"
+    - role: "system_swapfile"
     - role: "system_fail2ban"
     - role: "postfix_relay"
       vars:


### PR DESCRIPTION
- bump ansible-common submodule to pull in the new `system_swapfile` role
- add `system_swapfile` to `infrastructure/ansible/deploy.yml` between `system_hostname` and `system_fail2ban`
- use role defaults (`/swapfile`, 1G, `vm.swappiness=10`)