### PR TITLE
Ignore ActionController::BadRequest in exception notifications

### DIFF
--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -7,7 +7,11 @@ ExceptionNotification.configure do |config|
   # ActiveRecord::RecordNotFound, AbstractController::ActionNotFound and
   # ActionController::RoutingError are already added.
   # config.ignored_exceptions += %w{ActionView::TemplateError CustomError}
-  config.ignored_exceptions += %w[ActionDispatch::Http::MimeNegotiation::InvalidType URI::InvalidComponentError]
+  config.ignored_exceptions += %w[
+    ActionDispatch::Http::MimeNegotiation::InvalidType
+    URI::InvalidComponentError
+    ActionController::BadRequest
+  ]
 
   # Adds a condition to decide when an exception must be ignored or not.
   # The ignore_if method can be invoked multiple times to add extra conditions.


### PR DESCRIPTION
- bot probes sending malformed requests (e.g. GET to /users/sign_in with multipart/form-data Content-Type and empty body, fishing for the Next.js Server Actions CVE) raise Rack::Multipart::EmptyContentError, which Rails wraps as ActionController::BadRequest
- this triggered noisy alert emails, and the email rendering itself blew up because exception_notification's request partial calls request.filtered_parameters and re-raised the same error
- add ActionController::BadRequest to the existing ignored_exceptions list so these probes no longer page us