### PR TITLE
Update alerts email and add X-Origin-Host header

### DIFF
--- a/infrastructure/ansible/deploy.yml
+++ b/infrastructure/ansible/deploy.yml
@@ -34,6 +34,8 @@
         postfix_relay_password: "{{ lookup('env', 'SMTP_RELAY_PASSWORD') }}"
         postfix_relay_hostname: "{{ lookup('env', 'JQC_HOSTNAME') }}"
         postfix_relay_root_alias: "{{ lookup('env', 'ALERTS_EMAIL') }}"
+        postfix_relay_custom_headers:
+          - "X-Origin-Host: {{ lookup('env', 'JQC_HOSTNAME') }}"
     - role: "ansible_flush_handlers"
     - role: "system_logcheck"
     - role: "docker_install"

--- a/secrets.sops.env
+++ b/secrets.sops.env
@@ -3,7 +3,7 @@ SOPS_AGE_SECRET_KEY=ENC[AES256_GCM,data:hRMUl9oSX5PZyNwXDiFOLrYeMtq4AjF7ZT+w630u
 #ENC[AES256_GCM,data:728sRyJtt8w=,iv:jjE9MJ/6G8GH73fFBVBxoW3aQ4BKafracyabO5xmkMQ=,tag:sL95FrvV8nIgzQokSpVHgw==,type:comment]
 DOMAIN=ENC[AES256_GCM,data:6X2sIKKOBAuWykt7qcKECUZW1w==,iv:9w+rKXjr+UsUZeabSY6WDskAJwA0GpT3jS1hsCT5kZQ=,tag:dok32YOSDmtu4GnVJtRumQ==,type:str]
 #ENC[AES256_GCM,data:A6C5Mkb47YDXwr7iK0fBfrdFs1KN3WEvKAXhJzh1gXUyIwpbJUGPILl1gdGZC8CQbx2yKA==,iv:zCSoinYfMIpZbf+OseMEA3DpllXAPCYrcG/HUlvg/f8=,tag:v6obgteFD/xqlM+BUhoeQA==,type:comment]
-ALERTS_EMAIL=ENC[AES256_GCM,data:B+O8eHjNCB75+y+AaRAH0xP0,iv:gRm0qQToYkUuQQ5E6lkbR7jDREpsrMxKJfuCjJzIRw0=,tag:+AehKcfQO397mUrk10MFCA==,type:str]
+ALERTS_EMAIL=ENC[AES256_GCM,data:KL+GvUI6Nr8en1i7mgrzcpZCh+3q6yDl4g==,iv:IuF55ItN69sOzFs5Vu7V81DJaryy4pbo6uDFNJgXNXo=,tag:HJ/w2WyGsJK6zFygGLsRag==,type:str]
 #ENC[AES256_GCM,data:120z1I8XS5lQM/izyLo=,iv:z64aseFy7M1gxBbNHBgjwubrUttiyxVxoMVA8WkuaZQ=,tag:WLexCRrigupK18aFJ6aVOA==,type:comment]
 OPENTOFU_AWS_ACCESS_KEY_ID=ENC[AES256_GCM,data:yVT0DS5U7GclDjp1bLnCJNuTBek=,iv:4ijuoym9GL6zxGQRBiRYt+QsQRKIp8z19sXKfrdF+lk=,tag:WPUnrVPK2rJkWQZzM1OyvA==,type:str]
 OPENTOFU_AWS_SECRET_ACCESS_KEY=ENC[AES256_GCM,data:0iIxvWijdB1VjpUlO1bTmcot6J0UdpbXiG3ugyrIYRU148x4dUL9Xg==,iv:eRmE8WbT06UEnBCe83yyaBsfDoWtjKT0i8SHg/eYOcw=,tag:oHdR1zT+rgWbxQcSwn4vCA==,type:str]
@@ -27,10 +27,10 @@ MONITORING_GRAFANA_USER=ENC[AES256_GCM,data:LGaKlrWekAnEyA==,iv:20f0sxuW2bUuXCKQ
 MONITORING_GRAFANA_PASSWORD=ENC[AES256_GCM,data:JzyrsxOqLiWE4Qx1ZMXd3Q==,iv:SGncJj9t1dkNTfihlSYPV52i6BeT0BvN6B8hmwWSkXI=,tag:ehkA3SKfR2A8/nyevK9cRA==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGN0o2N2RucER5L2dHcXlX\nZjBmbkVZRjg0YzVYY2ZucEdnOFNPV0hwY3pzCml0dktQd2IwVTM3QXcyaXNSc0tJ\nSi8wZHdhTmFSMnhKUDhla0VZR1dLbjgKLS0tIHlvbUlFZ25sdmdTYXBMd0Jtazhn\nRGhZUHdnSUYrbWVOQW9JK2ZibFRJZ28K+mzZIruAEnH6efe3eb9R3S+255TwqCWT\nH5SFGk6xx/kL0cRka9bM9TIhFnvylly9SDltuj4Tvj2gTn60gs11xw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1378rd9z0z8f6ckuujhpafk30rn6667xqdyefsxzgvq3m9n63gvmqred5s3
-sops_lastmodified=2026-04-11T06:24:49Z
-sops_mac=ENC[AES256_GCM,data:2TM1vyrOJRA3cCr7PQtwxgGZhCCvGzPSxseQrmFTVZJIpD4VG812nNlQjcV6ga3LuRtvN9gWCexFLf1iAVrWC3xs1a7a0kU/gcKv0K9iNmCFC3NGLKvhrNdho/QwQ117RITTLdXSbKSKJd8K21eMB8yvFCgr6W2ctX7iHrRozNE=,iv:SJAvOgUfr8TtpQS1As/EKeZvtZoZyKHmKCZwzm4xyuA=,tag:zMo6eBklY1lRlenCcEqo3w==,type:str]
+sops_lastmodified=2026-05-27T01:21:35Z
+sops_mac=ENC[AES256_GCM,data:0zI2NERs4i4riGHbGIsxcUMeEWagDW33joX0K7aPln7QzKjQR4a0ozJ05dFr/1PqxCWbQxB1Zfsul/gzikumBPiTxvV55Ivo2EmyvRGHpLYY8zAfCPr45QtwJOJVQWTRDTTQljcUA0N4z0GLnvSy9vRiOCtOv9QrcGhTONTBL3o=,iv:9o35GDHBfzgGqqeBffVxi6uZA59n0PixO57lkELRmOc=,tag:ATPQq+1oyr4fqrUQ2lARBg==,type:str]
 sops_pgp__list_0__map_created_at=2026-03-24T08:36:34Z
 sops_pgp__list_0__map_enc=-----BEGIN PGP MESSAGE-----\n\nhF4DuRMJhX272rcSAQdA4KNKSkJvLzZaXCh0j+bQkaJOSp35YLTWomldqxs3UCAw\nZvtbkWy9HMz+xlw75byC6X6xsxikQ/JcrAV/P6Vu2KdvEjSTqWCV4aomIOYc+Aud\n1GYBCQIQzB0XVEY6r7fRtNhsxlIvY9AOPIaPspVbXge86I5HEAmoTF5zYrEzOToK\nhvGSjfdQSznJ7s0CZ8+hV6C3HCX/C96Q8xz2qG3lrrInfDrrPWIiGfk64PXj75u2\nJm7tioC21os=\n=g9Sk\n-----END PGP MESSAGE-----
 sops_pgp__list_0__map_fp=79B39318D5DD51A12808B4478672CEE1629D465B
 sops_unencrypted_suffix=_unencrypted
-sops_version=3.12.1
+sops_version=3.12.2


### PR DESCRIPTION
- Update the encrypted `ALERTS_EMAIL` value in `secrets.sops.env`
- Add `X-Origin-Host` custom header to postfix relay config in `infrastructure/ansible/deploy.yml` so outbound alert emails are tagged with the originating host
- Bump `sops_version` to 3.12.2 as a side effect of re-encrypting the secrets file