### PR TITLE
Add structural engineer notes field and rename certificate header

### DIFF
--- a/app/models/structural_engineer.rb
+++ b/app/models/structural_engineer.rb
@@ -22,6 +22,7 @@ class StructuralEngineer < ApplicationRecord
           se.structural_engineer_fee,
           se.engineer_certificate_received,
           se.certificate_reference,
+          se.structural_engineer_notes,
           se.structural_engineer_ok_to_pay,
           a.certification_notes
       FROM structural_engineers AS se

--- a/app/views/applications/form/_certification_fields.html.erb
+++ b/app/views/applications/form/_certification_fields.html.erb
@@ -102,14 +102,17 @@
                 <th class="fw-normal small">
                   <div class="ps-2 py-2">External Engineer</div>
                 </th>
-                <th class="fw-normal small">
+                <th class="fw-normal small" style="width: 9em">
                   <div class="ps-2 py-2">S.E Fee ($)</div>
                 </th>
                 <th class="fw-normal small">
-                  <div class="ps-2 py-2">Certificate received</div>
+                  <div class="ps-2 py-2">Certificate date</div>
                 </th>
                 <th class="fw-normal small">
                   <div class="ps-2 py-2">Certificate reference</div>
+                </th>
+                <th class="fw-normal small">
+                  <div class="ps-2 py-2">Notes</div>
                 </th>
                 <th class="fw-normal small">
                   <div class="ps-2 py-2">S.E OK to pay</div>

--- a/app/views/applications/tables/_structural_engineers_fields.html.erb
+++ b/app/views/applications/tables/_structural_engineers_fields.html.erb
@@ -20,6 +20,10 @@
     <%= f.text_field :certificate_reference %>
   </td>
   <td class="border-0 py-1">
+    <%= f.label :structural_engineer_notes, class: 'd-none' %>
+    <%= f.text_field :structural_engineer_notes %>
+  </td>
+  <td class="border-0 py-1">
     <%= f.label :structural_engineer_ok_to_pay, class: 'd-none' %>
     <%= f.check_box :structural_engineer_ok_to_pay %>
   </td>

--- a/db/migrate/20260703072237_add_structural_engineer_notes.rb
+++ b/db/migrate/20260703072237_add_structural_engineer_notes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStructuralEngineerNotes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :structural_engineers, :structural_engineer_notes, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -615,7 +615,8 @@ CREATE TABLE public.structural_engineers (
     structural_engineer_ok_to_pay boolean DEFAULT false NOT NULL,
     application_id bigint,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    structural_engineer_notes text
 );
 
 
@@ -1392,6 +1393,7 @@ ALTER TABLE ONLY public.structural_engineers
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260703072237'),
 ('20250808042802'),
 ('20250306231800'),
 ('20250227114919'),


### PR DESCRIPTION
- Add `structural_engineer_notes` column to `structural_engineers`
- Show a Notes field on the Certification page between Certificate reference and S.E OK to pay
- Narrow the S.E Fee column to make room for the new field
- Include the new column in the S.E report SQL
- Rename the "Certificate received" header to "Certificate date"